### PR TITLE
Use standard go error interface in OnRequest hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ err := client.Signal("eventA", wwr.Payload{Data: []byte("something")})
 The server also can send signals to individual connected clients.
 
 ```go
-func onRequest(ctx context.Context) (wwr.Payload, *wwr.Error) {
+func onRequest(ctx context.Context) (wwr.Payload, error) {
   msg := ctx.Value(wwr.Msg).(wwr.Message)
   // Send a signal to the client before replying to the request
   msg.Client.Signal("", wwr.Payload{Data: []byte("ping!")})
@@ -105,7 +105,7 @@ func onRequest(ctx context.Context) (wwr.Payload, *wwr.Error) {
 Different kinds of requests and signals can be differentiated using the builtin namespacing feature.
 
 ```go
-func onRequest(ctx context.Context) (wwr.Payload, *wwr.Error) {
+func onRequest(ctx context.Context) (wwr.Payload, error) {
   msg := ctx.Value(wwr.Msg).(wwr.Message)
   switch msg.Name {
   case "auth":
@@ -132,7 +132,7 @@ func onSignal(ctx context.Context) {
 Individual connections can get sessions assigned to identify them. The state of the session is automagically synchronized between the client and the server. WebWire doesn't enforce any kind of authentication technique though, it just provides you a way to authenticate a connection. WebWire also doesn't enforce any kind of session storage, it's up to the user to implement any kind of volatile or persistent session storage, be it a database or a simple map.
 
 ```go
-func onRequest(ctx context.Context) (wwr.Payload, *wwr.Error) {
+func onRequest(ctx context.Context) (wwr.Payload, error) {
   msg := ctx.Value(wwr.Msg).(wwr.Message)
   client := msg.Client
   // Verify credentials

--- a/client/client.go
+++ b/client/client.go
@@ -178,7 +178,7 @@ func (clt *Client) TimedRequest(
 	name string,
 	payload webwire.Payload,
 	timeout time.Duration,
-) (webwire.Payload, *webwire.Error) {
+) (webwire.Payload, error) {
 	reqType := webwire.MsgRequestBinary
 	switch payload.Encoding {
 	case webwire.EncodingUtf8:

--- a/client/requestSessionRestoration.go
+++ b/client/requestSessionRestoration.go
@@ -21,6 +21,7 @@ func (clt *Client) requestSessionRestoration(sessionKey []byte) (*webwire.Sessio
 	)
 	if err != nil {
 		// TODO: check for error types
+		fmt.Println("ERR", err)
 		return nil, fmt.Errorf("Session restoration request failed: %s", err)
 	}
 

--- a/examples/echo/server/server.go
+++ b/examples/echo/server/server.go
@@ -12,7 +12,7 @@ import (
 
 var serverAddr = flag.String("addr", ":8081", "server address")
 
-func onRequest(ctx context.Context) (wwr.Payload, *wwr.Error) {
+func onRequest(ctx context.Context) (wwr.Payload, error) {
 	msg := ctx.Value(wwr.Msg).(wwr.Message)
 	client := msg.Client
 

--- a/message.go
+++ b/message.go
@@ -19,6 +19,10 @@ type Error struct {
 	Message string `json:"m,omitempty"`
 }
 
+func (err Error) Error() string {
+	return err.Message
+}
+
 const (
 	// MsgMinLenSignal represents the minimum binary/UTF8 encoded signal message length
 	MsgMinLenSignal = int(3)

--- a/test/activeSessionRegistry_test.go
+++ b/test/activeSessionRegistry_test.go
@@ -18,7 +18,7 @@ func TestActiveSessionRegistry(t *testing.T) {
 	srv, addr := setupServer(
 		t,
 		webwire.Hooks{
-			OnRequest: func(ctx context.Context) (webwire.Payload, *webwire.Error) {
+			OnRequest: func(ctx context.Context) (webwire.Payload, error) {
 				// Extract request message and requesting client from the context
 				msg := ctx.Value(webwire.Msg).(webwire.Message)
 
@@ -32,7 +32,7 @@ func TestActiveSessionRegistry(t *testing.T) {
 
 				// Try to create a new session
 				if err := msg.Client.CreateSession(nil); err != nil {
-					return webwire.Payload{}, &webwire.Error{
+					return webwire.Payload{}, webwire.Error{
 						Code:    "INTERNAL_ERROR",
 						Message: fmt.Sprintf("Internal server error: %s", err),
 					}

--- a/test/authentication_test.go
+++ b/test/authentication_test.go
@@ -73,7 +73,7 @@ func TestAuthentication(t *testing.T) {
 				compareSessions(t, createdSession, msg.Client.Session)
 				compareSessionInfo(msg.Client.Session)
 			},
-			OnRequest: func(ctx context.Context) (wwr.Payload, *wwr.Error) {
+			OnRequest: func(ctx context.Context) (wwr.Payload, error) {
 				// Extract request message and requesting client from the context
 				msg := ctx.Value(wwr.Msg).(wwr.Message)
 
@@ -86,7 +86,7 @@ func TestAuthentication(t *testing.T) {
 
 				// Try to create a new session
 				if err := msg.Client.CreateSession(sessionInfo); err != nil {
-					return wwr.Payload{}, &wwr.Error{
+					return wwr.Payload{}, wwr.Error{
 						Code:    "INTERNAL_ERROR",
 						Message: fmt.Sprintf("Internal server error: %s", err),
 					}

--- a/test/clientAutomaticSessionRestoration_test.go
+++ b/test/clientAutomaticSessionRestoration_test.go
@@ -23,7 +23,7 @@ func TestClientAutomaticSessionRestoration(t *testing.T) {
 	_, addr := setupServer(
 		t,
 		webwire.Hooks{
-			OnRequest: func(ctx context.Context) (webwire.Payload, *webwire.Error) {
+			OnRequest: func(ctx context.Context) (webwire.Payload, error) {
 				// Extract request message and requesting client from the context
 				msg := ctx.Value(webwire.Msg).(webwire.Message)
 
@@ -35,7 +35,7 @@ func TestClientAutomaticSessionRestoration(t *testing.T) {
 
 				// Try to create a new session
 				if err := msg.Client.CreateSession(nil); err != nil {
-					return webwire.Payload{}, &webwire.Error{
+					return webwire.Payload{}, webwire.Error{
 						Code:    "INTERNAL_ERROR",
 						Message: fmt.Sprintf("Internal server error: %s", err),
 					}

--- a/test/clientConcurrentRequest_test.go
+++ b/test/clientConcurrentRequest_test.go
@@ -20,7 +20,7 @@ func TestClientConcurrentRequest(t *testing.T) {
 	_, addr := setupServer(
 		t,
 		webwire.Hooks{
-			OnRequest: func(_ context.Context) (webwire.Payload, *webwire.Error) {
+			OnRequest: func(_ context.Context) (webwire.Payload, error) {
 				finished.Done()
 				return webwire.Payload{}, nil
 			},

--- a/test/clientInitiatedSessionDestruction_test.go
+++ b/test/clientInitiatedSessionDestruction_test.go
@@ -31,7 +31,7 @@ func TestClientInitiatedSessionDestruction(t *testing.T) {
 	_, addr := setupServer(
 		t,
 		webwire.Hooks{
-			OnRequest: func(ctx context.Context) (webwire.Payload, *webwire.Error) {
+			OnRequest: func(ctx context.Context) (webwire.Payload, error) {
 				// Extract request message and requesting client from the context
 				msg := ctx.Value(webwire.Msg).(webwire.Message)
 
@@ -62,7 +62,7 @@ func TestClientInitiatedSessionDestruction(t *testing.T) {
 
 				// On step 1 - authenticate and create a new session
 				if err := msg.Client.CreateSession(nil); err != nil {
-					return webwire.Payload{}, &webwire.Error{
+					return webwire.Payload{}, webwire.Error{
 						Code:    "INTERNAL_ERROR",
 						Message: fmt.Sprintf("Internal server error: %s", err),
 					}

--- a/test/clientOfflineSessionClosure_test.go
+++ b/test/clientOfflineSessionClosure_test.go
@@ -22,7 +22,7 @@ func TestClientOfflineSessionClosure(t *testing.T) {
 	_, addr := setupServer(
 		t,
 		webwire.Hooks{
-			OnRequest: func(ctx context.Context) (webwire.Payload, *webwire.Error) {
+			OnRequest: func(ctx context.Context) (webwire.Payload, error) {
 				// Extract request message and requesting client from the context
 				msg := ctx.Value(webwire.Msg).(webwire.Message)
 
@@ -36,7 +36,7 @@ func TestClientOfflineSessionClosure(t *testing.T) {
 
 				// Try to create a new session
 				if err := msg.Client.CreateSession(nil); err != nil {
-					return webwire.Payload{}, &webwire.Error{
+					return webwire.Payload{}, webwire.Error{
 						Code:    "INTERNAL_ERROR",
 						Message: fmt.Sprintf("Internal server error: %s", err),
 					}

--- a/test/clientOnSessionClosed_test.go
+++ b/test/clientOnSessionClosed_test.go
@@ -20,13 +20,13 @@ func TestClientOnSessionClosed(t *testing.T) {
 	_, addr := setupServer(
 		t,
 		webwire.Hooks{
-			OnRequest: func(ctx context.Context) (webwire.Payload, *webwire.Error) {
+			OnRequest: func(ctx context.Context) (webwire.Payload, error) {
 				// Extract request message and requesting client from the context
 				msg := ctx.Value(webwire.Msg).(webwire.Message)
 
 				// Try to create a new session
 				if err := msg.Client.CreateSession(nil); err != nil {
-					return webwire.Payload{}, &webwire.Error{
+					return webwire.Payload{}, webwire.Error{
 						Code:    "INTERNAL_ERROR",
 						Message: fmt.Sprintf("Internal server error: %s", err),
 					}

--- a/test/clientOnSessionCreated_test.go
+++ b/test/clientOnSessionCreated_test.go
@@ -21,13 +21,13 @@ func TestClientOnSessionCreated(t *testing.T) {
 	_, addr := setupServer(
 		t,
 		webwire.Hooks{
-			OnRequest: func(ctx context.Context) (webwire.Payload, *webwire.Error) {
+			OnRequest: func(ctx context.Context) (webwire.Payload, error) {
 				// Extract request message and requesting client from the context
 				msg := ctx.Value(webwire.Msg).(webwire.Message)
 
 				// Try to create a new session
 				if err := msg.Client.CreateSession(nil); err != nil {
-					return webwire.Payload{}, &webwire.Error{
+					return webwire.Payload{}, webwire.Error{
 						Code:    "INTERNAL_ERROR",
 						Message: fmt.Sprintf("Internal server error: %s", err),
 					}

--- a/test/clientRequestError_test.go
+++ b/test/clientRequestError_test.go
@@ -26,10 +26,9 @@ func TestClientRequestError(t *testing.T) {
 	_, addr := setupServer(
 		t,
 		webwire.Hooks{
-			OnRequest: func(_ context.Context) (webwire.Payload, *webwire.Error) {
+			OnRequest: func(_ context.Context) (webwire.Payload, error) {
 				// Fail the request by returning an error
-				err := expectedReplyError
-				return webwire.Payload{}, &err
+				return webwire.Payload{}, expectedReplyError
 			},
 		},
 	)

--- a/test/clientRequestRegisterOnReply_test.go
+++ b/test/clientRequestRegisterOnReply_test.go
@@ -19,7 +19,7 @@ func TestClientRequestRegisterOnReply(t *testing.T) {
 	_, addr := setupServer(
 		t,
 		webwire.Hooks{
-			OnRequest: func(ctx context.Context) (webwire.Payload, *webwire.Error) {
+			OnRequest: func(ctx context.Context) (webwire.Payload, error) {
 				// Verify pending requests
 				pendingReqs := client.PendingRequests()
 				if pendingReqs != 1 {

--- a/test/clientRequestRegisterOnTimeout_test.go
+++ b/test/clientRequestRegisterOnTimeout_test.go
@@ -19,7 +19,7 @@ func TestClientRequestRegisterOnTimeout(t *testing.T) {
 	_, addr := setupServer(
 		t,
 		webwire.Hooks{
-			OnRequest: func(ctx context.Context) (webwire.Payload, *webwire.Error) {
+			OnRequest: func(ctx context.Context) (webwire.Payload, error) {
 				// Verify pending requests
 				pendingReqs := client.PendingRequests()
 				if pendingReqs != 1 {

--- a/test/clientRequest_test.go
+++ b/test/clientRequest_test.go
@@ -26,7 +26,7 @@ func TestClientRequest(t *testing.T) {
 	_, addr := setupServer(
 		t,
 		webwire.Hooks{
-			OnRequest: func(ctx context.Context) (webwire.Payload, *webwire.Error) {
+			OnRequest: func(ctx context.Context) (webwire.Payload, error) {
 				// Extract request message from the context
 				msg := ctx.Value(webwire.Msg).(webwire.Message)
 

--- a/test/clientSessionRestoration_test.go
+++ b/test/clientSessionRestoration_test.go
@@ -22,7 +22,7 @@ func TestClientSessionRestoration(t *testing.T) {
 	_, addr := setupServer(
 		t,
 		webwire.Hooks{
-			OnRequest: func(ctx context.Context) (webwire.Payload, *webwire.Error) {
+			OnRequest: func(ctx context.Context) (webwire.Payload, error) {
 				// Extract request message and requesting client from the context
 				msg := ctx.Value(webwire.Msg).(webwire.Message)
 
@@ -34,7 +34,7 @@ func TestClientSessionRestoration(t *testing.T) {
 
 				// Try to create a new session
 				if err := msg.Client.CreateSession(nil); err != nil {
-					return webwire.Payload{}, &webwire.Error{
+					return webwire.Payload{}, webwire.Error{
 						Code:    "INTERNAL_ERROR",
 						Message: fmt.Sprintf("Internal server error: %s", err),
 					}

--- a/test/emptyReplyUtf16_test.go
+++ b/test/emptyReplyUtf16_test.go
@@ -16,7 +16,7 @@ func TestEmptyReplyUtf16(t *testing.T) {
 	_, addr := setupServer(
 		t,
 		wwr.Hooks{
-			OnRequest: func(_ context.Context) (wwr.Payload, *wwr.Error) {
+			OnRequest: func(_ context.Context) (wwr.Payload, error) {
 				// Return empty reply
 				return wwr.Payload{
 					Encoding: wwr.EncodingUtf16,

--- a/test/emptyReply_test.go
+++ b/test/emptyReply_test.go
@@ -16,7 +16,7 @@ func TestEmptyReply(t *testing.T) {
 	_, addr := setupServer(
 		t,
 		wwr.Hooks{
-			OnRequest: func(_ context.Context) (wwr.Payload, *wwr.Error) {
+			OnRequest: func(_ context.Context) (wwr.Payload, error) {
 				// Return empty reply
 				return wwr.Payload{}, nil
 			},

--- a/test/requestNamespaces_test.go
+++ b/test/requestNamespaces_test.go
@@ -25,7 +25,7 @@ func TestRequestNamespaces(t *testing.T) {
 	_, addr := setupServer(
 		t,
 		webwire.Hooks{
-			OnRequest: func(ctx context.Context) (webwire.Payload, *webwire.Error) {
+			OnRequest: func(ctx context.Context) (webwire.Payload, error) {
 				msg := ctx.Value(webwire.Msg).(webwire.Message)
 
 				if currentStep == 1 && msg.Name != "" {

--- a/test/serverInitiatedSessionDestruction_test.go
+++ b/test/serverInitiatedSessionDestruction_test.go
@@ -30,7 +30,7 @@ func TestServerInitiatedSessionDestruction(t *testing.T) {
 	_, addr := setupServer(
 		t,
 		webwire.Hooks{
-			OnRequest: func(ctx context.Context) (webwire.Payload, *webwire.Error) {
+			OnRequest: func(ctx context.Context) (webwire.Payload, error) {
 				// Extract request message and requesting client from the context
 				msg := ctx.Value(webwire.Msg).(webwire.Message)
 
@@ -84,7 +84,7 @@ func TestServerInitiatedSessionDestruction(t *testing.T) {
 
 				// On step 1 - authenticate and create a new session
 				if err := msg.Client.CreateSession(nil); err != nil {
-					return webwire.Payload{}, &webwire.Error{
+					return webwire.Payload{}, webwire.Error{
 						Code:    "INTERNAL_ERROR",
 						Message: fmt.Sprintf("Internal server error: %s", err),
 					}


### PR DESCRIPTION
Make the OnRequest hook accept a standard go error interface in return.