### PR TITLE
Add support for https listen

### DIFF
--- a/serverOptions.go
+++ b/serverOptions.go
@@ -32,6 +32,9 @@ type ServerOptions struct {
 	Heartbeat             OptionValue
 	HeartbeatTimeout      time.Duration
 	HeartbeatInterval     time.Duration
+	TLS                   OptionValue
+	TLSCertFile           string
+	TLSKeyFile            string
 	WarnLog               *log.Logger
 	ErrorLog              *log.Logger
 }
@@ -72,6 +75,10 @@ func (srvOpt *ServerOptions) SetDefaults() {
 	// if the specified timeout is below 1 second
 	if srvOpt.HeartbeatInterval < 1*time.Second {
 		srvOpt.HeartbeatInterval = 30 * time.Second
+	}
+
+	if srvOpt.TLS == OptionUnset {
+		srvOpt.TLS = Disabled
 	}
 
 	// Create default loggers to std-out/err when no loggers are specified


### PR DESCRIPTION
We can set on front https endpoint, but without any proxy (nginx etc) can not listen https with webwire server.
This pr add support for tls listen